### PR TITLE
Update and rename Fz_Euler.msg to FzEuler.msg

### DIFF
--- a/msg/FzEuler.msg
+++ b/msg/FzEuler.msg
@@ -1,0 +1,7 @@
+uint64 timestamp #time since system start (microseconds)
+
+float32 fz
+
+float32 phi 
+float32 theta
+float32 yaw 

--- a/msg/Fz_Euler.msg
+++ b/msg/Fz_Euler.msg
@@ -1,7 +1,0 @@
-unint64 timestamp #time since system start (microseconds)
-
-float32 fz
-
-float32 phi 
-float32 theta
-float32 yaw 


### PR DESCRIPTION
MATLAB doesn't like underscores in msg file names.

Corrected "unint64" to "uint64".